### PR TITLE
Adding backwards compatibility to the book model config

### DIFF
--- a/Xplat/src/main/java/vazkii/patchouli/common/book/Book.java
+++ b/Xplat/src/main/java/vazkii/patchouli/common/book/Book.java
@@ -109,7 +109,7 @@ public class Book {
 		this.bookTexture = SerializationUtil.getAsResourceLocation(root, "book_texture", DEFAULT_BOOK_TEXTURE);
 		this.fillerTexture = SerializationUtil.getAsResourceLocation(root, "filler_texture", DEFAULT_FILLER_TEXTURE);
 		this.craftingTexture = SerializationUtil.getAsResourceLocation(root, "crafting_texture", DEFAULT_CRAFTING_TEXTURE);
-		this.model = SerializationUtil.getAsResourceLocation(root, "model", DEFAULT_MODEL);
+		this.model = SerializationUtil.getAsResourceLocation(root, "model", DEFAULT_MODEL, "item/");
 		this.useBlockyFont = GsonHelper.getAsBoolean(root, "use_blocky_font", false);
 
 		this.owner = owner;

--- a/Xplat/src/main/java/vazkii/patchouli/common/util/SerializationUtil.java
+++ b/Xplat/src/main/java/vazkii/patchouli/common/util/SerializationUtil.java
@@ -30,7 +30,19 @@ public final class SerializationUtil {
 			return fallback;
 		}
 	}
-
+	public static ResourceLocation getAsResourceLocation(JsonObject object, String key, @Nullable ResourceLocation fallback, String prefix) {
+		// This adds backwards compatibility for old model locations that don't have the `item/` prefix
+		if (object.has(key)) {
+			var loc = GsonHelper.convertToString(object.get(key), key);
+			if (!prefix.isEmpty() && !loc.contains(prefix)) {
+				// loc= "minecraft:foo" -> "minecraft:item/foo"
+				loc = loc.substring(0, loc.indexOf(':') + 1) + prefix + loc.substring(loc.indexOf(':') + 1);
+			}
+			return ResourceLocation.tryParse(loc);
+		} else {
+			return fallback;
+		}
+	}
 	@Nullable
 	public static <T extends Enum<T>> T getAsEnum(JsonObject object, String key, Class<T> clz, @Nullable T fallback) {
 		if (object.has(key)) {


### PR DESCRIPTION
This makes sure that the books from other mods that might not have the `item/` in the model path as required by the new version.